### PR TITLE
HOTFIX - Adds missing cypress dependency

### DIFF
--- a/base/package.json
+++ b/base/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-cypress": "^2.11.3",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0"
   },


### PR DESCRIPTION
Required [here](https://github.com/35up/eslint-config-35up/blob/master/base/index.js#L189)