### PR TITLE
HOTFIX - Allows object literal uppercased keys

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -118,7 +118,7 @@ module.exports = {
         '@typescript-eslint/naming-convention': [
           'warn',
           {
-            selector: ['enum', 'enumMember'],
+            selector: ['enum', 'enumMember', 'objectLiteralProperty'],
             format: ['UPPER_CASE'],
           },
           {

--- a/react/index.js
+++ b/react/index.js
@@ -114,7 +114,7 @@ module.exports = {
     '@typescript-eslint/naming-convention': [
       'warn',
       {
-        selector: ['enum', 'enumMember'],
+        selector: ['enum', 'enumMember', 'objectLiteralProperty'],
         format: ['UPPER_CASE'],
       },
       {


### PR DESCRIPTION
use case in aengus when creating an object of constant values like this:
```
export const LINKS = {
  HOMEPAGE: 'https://www.35up.com',
  BENEFITS: 'https://35up.com/en/benefits',
  CUSTOMER_STORIES: 'https://35up.com/en/customer-stories',
  BLOG: 'https://35up.com/en/blog',
  ...
};
```

What do you think?