### PR TITLE
UP-4273 - Forbids `.only` and `.skip` in tests

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['eslint:recommended', 'airbnb-base'],
-  plugins: ['import', '@typescript-eslint'],
+  plugins: ['import', '@typescript-eslint', 'no-only-tests'],
   env: {
     es6: true,
   },
@@ -54,6 +54,8 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'import/no-unresolved': 'off',
     'no-use-before-define': 'off',
+    'no-only-tests/no-only-tests': ['error', {focus: ['only', 'skip']},
+    ],
   },
   overrides: [
     {
@@ -124,7 +126,7 @@ module.exports = {
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/no-unused-expressions': 'error',
         '@typescript-eslint/prefer-enum-initializers': 'error',
-        '@typescript-eslint/ban-types': ['error', {types: {"{}": false}}],
+        '@typescript-eslint/ban-types': ['error', {types: {'{}': false}}],
         '@typescript-eslint/naming-convention': [
           'warn',
           {
@@ -282,7 +284,7 @@ module.exports = {
             leadingUnderscore: 'allowSingleOrDouble',
             format: null,
           },
-        ]
+        ],
       },
     },
   ],

--- a/base/package.json
+++ b/base/package.json
@@ -11,7 +11,8 @@
     "@typescript-eslint/parser": "^5.30.7",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-cypress": "^2.12.1",
-    "eslint-plugin-import": "^2.26.0"
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-no-only-tests": "^3.1.0"
   },
   "peerDependencies": {
     "eslint": "^8.20.0"

--- a/react/index.js
+++ b/react/index.js
@@ -38,7 +38,6 @@ module.exports = {
     ],
     'react/jsx-handler-names': 'off',
     'react/jsx-indent-props': ['error', 2],
-    'react/jsx-max-props-per-line': ['error', {maximum: 1, when: 'multiline'}],
     'react/jsx-pascal-case': 'error',
     'react/prefer-es6-class': ['error', 'always'],
     'react/no-unused-class-component-methods': 'error',


### PR DESCRIPTION
`react/jsx-max-props-per-line` was removed as there were 2 definitions for the same rule